### PR TITLE
Procurement Requests API Enhancements

### DIFF
--- a/database/models/user.js
+++ b/database/models/user.js
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
 
       // User can have many procurement requests
       User.hasMany(models.ProcurementRequest, {
-        foreignKey: 'user_id',
+        foreignKey: 'buyer_id',
         as: 'procurementRequests',
         onUpdate: 'CASCADE',
         onDelete: 'CASCADE',

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const userRoutes = require('./src/routes/userRoutes.js');
 const adminUserRoutes = require('./src/routes/routes.js'); 
 const authRoutes = require('./src/routes/authRoutes.js');
 const adminRoutes = require('./src/routes/adminRoutes.js');
+const procurementRoutes = require('./src/routes/procurementRoutes.js');
 
 const app = express();
 
@@ -22,6 +23,7 @@ app.use('/api', userRoutes);
 app.use('/api', adminUserRoutes); 
 app.use('/api/auth', authRoutes); 
 app.use('/api',adminRoutes);
+app.use('/api', procurementRoutes);
 
 app.listen(serverConfig.port, () => {
     console.log(`Server is running on port ${serverConfig.port}`);

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -34,6 +34,7 @@ router.get('/procurement/requests', verifyToken, async (req, res) => {
   }
 });
 
+// Ruta za filtriranje zahtjeva po kategoriji
 router.get('/procurement/requests/category/:categoryId', verifyToken, async (req, res) => {
     try {
       const { categoryId } = req.params;
@@ -52,7 +53,7 @@ router.get('/procurement/requests/category/:categoryId', verifyToken, async (req
             attributes: ['id', 'name']
           }
         ],
-        order: [['createdAt', 'DESC']]
+        order: [['created_at', 'DESC']]
       });
   
       res.status(200).json({ requests });
@@ -61,7 +62,5 @@ router.get('/procurement/requests/category/:categoryId', verifyToken, async (req
       res.status(500).json({ error: error.message });
     }
   });
-  
-  
 
 module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -34,5 +34,33 @@ router.get('/procurement/requests', verifyToken, async (req, res) => {
   }
 });
 
+router.get('/procurement/requests/category/:categoryId', verifyToken, async (req, res) => {
+    try {
+      const { category_id } = req.params;
+      
+      const requests = await db.ProcurementRequest.findAll({
+        where: { category_id },
+        include: [
+          {
+            model: db.User,
+            as: 'buyers',
+            attributes: ['id', 'first_name', 'last_name', 'company_name']
+          },
+          {
+            model: db.ProcurementCategory,
+            as: 'procurementCategory',
+            attributes: ['id', 'name']
+          }
+        ],
+        order: [['createdAt', 'DESC']]
+      });
+  
+      res.status(200).json({ requests });
+    } catch (error) {
+      console.error('Error fetching procurement requests by category:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+  
 
 module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const router = express.Router();
+const { verifyToken } = require('../middleware/authMiddleware');
+const db = require('../../database/models');
+
+// Ruta za dohvat svih zahtjeva za nabavku
+router.get('/procurement/requests', verifyToken, async (req, res) => {
+  try {
+    const requests = await db.ProcurementRequest.findAll({
+      include: [
+        {
+          model: db.User,
+          as: 'buyer',
+          attributes: ['id', 'first_name', 'last_name', 'company_name', 'email']
+        },
+        {
+          model: db.ProcurementCategory,
+          as: 'procurementCategory',
+          attributes: ['id', 'name']
+        },
+        {
+          model: db.ProcurementItem,
+          as: 'items',
+          attributes: ['id', 'title', 'quantity']
+        }
+      ],
+      order: [['created_at', 'DESC']]
+    });
+
+    res.status(200).json({ requests });
+  } catch (error) {
+    console.error('Error fetching procurement requests:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+
+module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -36,14 +36,14 @@ router.get('/procurement/requests', verifyToken, async (req, res) => {
 
 router.get('/procurement/requests/category/:categoryId', verifyToken, async (req, res) => {
     try {
-      const { category_id } = req.params;
+      const { categoryId } = req.params;
       
       const requests = await db.ProcurementRequest.findAll({
-        where: { category_id },
+        where: { category_id: categoryId },
         include: [
           {
             model: db.User,
-            as: 'buyers',
+            as: 'buyer',
             attributes: ['id', 'first_name', 'last_name', 'company_name']
           },
           {
@@ -61,6 +61,7 @@ router.get('/procurement/requests/category/:categoryId', verifyToken, async (req
       res.status(500).json({ error: error.message });
     }
   });
+  
   
 
 module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -63,4 +63,23 @@ router.get('/procurement/requests/category/:categoryId', verifyToken, async (req
     }
   });
 
+
+// Ruta za detalje pojedinačnog zahtjeva
+router.get('/procurement/requests/:id', verifyToken, async (req, res) => {
+    try {
+      const { id } = req.params;
+  
+      const request = await db.ProcurementRequest.findByPk(id);
+  
+      if (!request) {
+        return res.status(404).json({ error: 'Procurement request not found' });
+      }
+  
+      res.status(200).json({ request });
+    } catch (error) {
+      console.error('Error fetching procurement request details:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+  
 module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -36,44 +36,44 @@ router.get('/procurement/requests', verifyToken, async (req, res) => {
 
 // Ruta za filtriranje zahtjeva po kategoriji
 router.get('/procurement/requests/category/:categoryId', verifyToken, async (req, res) => {
-    try {
-      const { categoryId } = req.params;
-      
-      const requests = await db.ProcurementRequest.findAll({
-        where: { category_id: categoryId },
-        include: [
-          {
-            model: db.User,
-            as: 'buyer',
-            attributes: ['id', 'first_name', 'last_name', 'company_name']
-          },
-          {
-            model: db.ProcurementCategory,
-            as: 'procurementCategory',
-            attributes: ['id', 'name']
-          }
-        ],
-        order: [['created_at', 'DESC']]
-      });
-  
-      res.status(200).json({ requests });
-    } catch (error) {
-      console.error('Error fetching procurement requests by category:', error);
-      res.status(500).json({ error: error.message });
-    }
-  });
+  try {
+    const { categoryId } = req.params;
+    
+    const requests = await db.ProcurementRequest.findAll({
+      where: { category_id: categoryId },
+      include: [
+        {
+          model: db.User,
+          as: 'buyer',
+          attributes: ['id', 'first_name', 'last_name', 'company_name']
+        },
+        {
+          model: db.ProcurementCategory,
+          as: 'procurementCategory',
+          attributes: ['id', 'name']
+        }
+      ],
+      order: [['created_at', 'DESC']]
+    });
 
+    res.status(200).json({ requests });
+  } catch (error) {
+    console.error('Error fetching procurement requests by category:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
 
 // Ruta za detalje pojedinačnog zahtjeva
 router.get('/procurement/requests/:id', verifyToken, async (req, res) => {
   try {
     const { id } = req.params;
-
+    
     const request = await db.ProcurementRequest.findByPk(id, {
       include: [
         {
           model: db.User,
-          attributes: ['id', 'first_name', 'last_name'] 
+          as: 'buyer',
+          attributes: ['id', 'first_name', 'last_name', 'company_name', 'email', 'phone_number']
         },
         {
           model: db.ProcurementCategory,
@@ -101,5 +101,4 @@ router.get('/procurement/requests/:id', verifyToken, async (req, res) => {
   }
 });
 
-  
 module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -101,4 +101,18 @@ router.get('/procurement/requests/:id', verifyToken, async (req, res) => {
   }
 });
 
+// Ruta za dohvat svih kategorija nabave (sortiranih po nazivu)
+router.get('/procurement/categories', verifyToken, async (req, res) => {
+  try {
+    const categories = await db.ProcurementCategory.findAll({
+      order: [['name', 'ASC']]
+    });
+    
+    res.status(200).json({ categories });
+  } catch (error) {
+    console.error('Error fetching categories:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -66,20 +66,40 @@ router.get('/procurement/requests/category/:categoryId', verifyToken, async (req
 
 // Ruta za detalje pojedinačnog zahtjeva
 router.get('/procurement/requests/:id', verifyToken, async (req, res) => {
-    try {
-      const { id } = req.params;
-  
-      const request = await db.ProcurementRequest.findByPk(id);
-  
-      if (!request) {
-        return res.status(404).json({ error: 'Procurement request not found' });
-      }
-  
-      res.status(200).json({ request });
-    } catch (error) {
-      console.error('Error fetching procurement request details:', error);
-      res.status(500).json({ error: error.message });
+  try {
+    const { id } = req.params;
+
+    const request = await db.ProcurementRequest.findByPk(id, {
+      include: [
+        {
+          model: db.User,
+          attributes: ['id', 'first_name', 'last_name'] 
+        },
+        {
+          model: db.ProcurementCategory,
+          as: 'procurementCategory'
+        },
+        {
+          model: db.ProcurementItem,
+          as: 'items'
+        },
+        {
+          model: db.Requirement,
+          as: 'requirements'
+        }
+      ]
+    });
+
+    if (!request) {
+      return res.status(404).json({ error: 'Procurement request not found' });
     }
-  });
+
+    res.status(200).json({ request });
+  } catch (error) {
+    console.error('Error fetching procurement request details:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
   
 module.exports = router;

--- a/src/routes/procurementRoutes.js
+++ b/src/routes/procurementRoutes.js
@@ -6,11 +6,13 @@ const db = require('../../database/models');
 // Ruta za dohvat svih zahtjeva za nabavku
 router.get('/procurement/requests', verifyToken, async (req, res) => {
   try {
+    console.log('Fetching procurement requests...');
     const requests = await db.ProcurementRequest.findAll({
       include: [
         {
           model: db.User,
           as: 'buyer',
+          foreignKey: 'buyer_id',  
           attributes: ['id', 'first_name', 'last_name', 'company_name', 'email']
         },
         {


### PR DESCRIPTION
- GET /api/procurement/requests: Fetch all procurement requests (latest first meaninng sorted by Date), including buyer, category, and items.

- GET /api/procurement/requests/category/:categoryId: Filter requests by procurement category.

- GET /api/procurement/requests/:id: View detailed info for a single request with all related data (buyer, category, items, requirements).

- GET /api/procurement/categories: Fetch all available procurement categories, sorted alphabetically.

Step-by-step that I took to test in Postman:
![Screenshot (61)](https://github.com/user-attachments/assets/8da4b4e7-5bc3-45c5-990e-e5038675d462)
![Screenshot (62)](https://github.com/user-attachments/assets/83c506e7-9fd9-4427-aea6-3a26f302168e)
![Screenshot (63)](https://github.com/user-attachments/assets/314f521f-685e-469d-9f1b-0b80f541f83c)
![Screenshot (64)](https://github.com/user-attachments/assets/c1bd5c50-516f-4db0-8c96-986e19c1961a)
![Screenshot (65)](https://github.com/user-attachments/assets/6b82b784-e1c1-4d2f-96bc-1edd353a8faa)
