### PR TITLE
Bid documents/4 upload - issue #32

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,10 @@ app.listen(serverConfig.port, () => {
     - GET /api/procurement-requests/buyer - Get all procurement requests (buyers only)
     - GET /api/procurement-requests/favorites - Get favorite procurement requests (sellers only)
     - POST /api/procurement-requests/:id/follow - Follow (add to favorites) procurement request (sellers only)
-    - DELETE /api/procurement-requests/:id/unfollow - Unfollow (remove from favorites) procurement request (sellers only)`);
+    - DELETE /api/procurement-requests/:id/unfollow - Unfollow (remove from favorites) procurement request (sellers only)
+    - POST /bid-documents/upload - Upload bid document (sellers only)
+    - DELETE /bid-documents/:id/remove - Remove bid document (sellers only)
+    - GET /procurement-bid/:id/bid-documents - Get bid documents for a specific procurement request`);
 });
 
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const procurementRoutesBuyer = require('./src/routes/procurementRoutes.js');
 const categoryRoutes = require('./src/routes/categoryRoutes');
 const buyerTypeRoutes = require('./src/routes/buyerTypeRoutes.js');
 const procurementRoutes = require('./src/routes/procurementRequestRoutes.js');
+const bidDocumentRoutes = require('./src/routes/bidDocumentRoutes.js');
 
 const app = express();
 
@@ -31,6 +32,7 @@ app.use('/api', procurementRoutes);
 app.use('/api', categoryRoutes);
 app.use('/api', buyerTypeRoutes);
 app.use('/api', procurementRoutes);
+app.use('/api', bidDocumentRoutes);
 
 app.listen(serverConfig.port, () => {
     console.log(`Server is running on port ${serverConfig.port}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@supabase/supabase-js": "^2.49.4",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
@@ -97,6 +98,73 @@
         "node": ">=14"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.69.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.1.tgz",
+      "integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.49.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.4.tgz",
+      "integrity": "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw==",
+      "dependencies": {
+        "@supabase/auth-js": "2.69.1",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.2",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -118,10 +186,23 @@
         "undici-types": "~6.20.0"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
+    },
     "node_modules/@types/validator": {
       "version": "13.12.3",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.3.tgz",
       "integrity": "sha512-2ipwZ2NydGQJImne+FhNdhgRM37e9lCev99KnqkbFHd94Xn/mErARWI1RSLem1QA19ch5kOhzIZd7e8CA2FI8g=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/abbrev": {
       "version": "2.0.0",
@@ -3292,6 +3373,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@supabase/supabase-js": "^2.49.4",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",

--- a/src/config/redis.js
+++ b/src/config/redis.js
@@ -1,0 +1,5 @@
+require('dotenv').config();
+
+module.exports = {
+    redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
+};

--- a/src/config/supabase.js
+++ b/src/config/supabase.js
@@ -1,0 +1,7 @@
+require('dotenv').config();
+
+module.exports = {
+    secretKey: process.env.SUPABASE_SECRET_KEY,
+    url: process.env.SUPABASE_URL,
+    bucketName: process.env.SUPABASE_BUCKET_NAME || 'procurehub-storage',
+};

--- a/src/controllers/bidDocumentController.js
+++ b/src/controllers/bidDocumentController.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const crypto = require('crypto');
+const supabaseBucketService = require("../services/supabaseBucketService");
+const bidDocumentRepository = require("../repositories/bidDocumentRepository");
+
+exports.uploadBidDocument = async (req, res) => {
+    const file = req.file;
+    if (!file) {
+        return res.status(400).json({ message: "No file uploaded" });
+    }
+
+    const userId = req.user.id;
+    const procurementBidId = req.body.procurement_bid_id;
+    const originalName = file.originalname;
+    const extension = path.extname(file.originalname);
+    const uniqueName = `${Date.now()}_${crypto.randomBytes(8).toString('hex')}`;
+    const destinationPath = `documents/user_${userId}_bid_${procurementBidId}_${uniqueName}${extension}`;
+
+    const result = await supabaseBucketService.uploadFile(file.buffer, file.mimetype, destinationPath);
+    if (!result) {
+        return res.status(500).json({ message: "Failed to upload file" });
+    }
+
+    const bidDocument = await bidDocumentRepository.addBidDocument(procurementBidId, originalName, result.path, file.mimetype);
+    if (!bidDocument) {
+        return res.status(500).json({ message: "Failed to save document information" });
+    }
+
+
+    return res.status(200).json({ message: "Uploaded successfully", bidDocument });
+}
+
+exports.deleteBidDocument = async (req, res) => {
+    const { id } = req.params;
+    if (!id) {
+        return res.status(400).json({ message: "No ID provided" });
+    }
+
+    const bidDocument = await bidDocumentRepository.getBidDocument(id);
+    const filePath = bidDocument.file_path;
+
+    const removedCount = await bidDocumentRepository.removeBidDocument(id);
+    if (!removedCount) {
+        return res.status(500).json({ message: "Failed to delete document information" });
+    }
+
+    const deleted = await supabaseBucketService.deleteFile(filePath);
+
+    return res.status(200).json({ message: "File deleted successfully" });
+}

--- a/src/middleware/uploadImageMiddleware.js
+++ b/src/middleware/uploadImageMiddleware.js
@@ -1,7 +1,7 @@
 const multer = require("multer");
 const path = require("path");
 
-const allowedExtensions = ['.doc', '.docx', '.pdf', '.jpg', '.jpeg', '.png'];
+const allowedExtensions = ['.jpg', '.jpeg', '.png'];
 
 const storage = multer.memoryStorage();
 
@@ -15,7 +15,7 @@ const upload = multer({
         if (allowedExtensions.includes(ext)) {
             cb(null, true);
         } else {
-            req.fileValidationError = "Only .doc, .docx, .pdf, .jpg, .jpeg, and .png files are allowed";
+            req.fileValidationError = "Only .jpg, .jpeg, and .png files are allowed";
             cb(null, false, req.fileValidationError);
         }
     }

--- a/src/repositories/bidDocumentRepository.js
+++ b/src/repositories/bidDocumentRepository.js
@@ -45,3 +45,18 @@ exports.getBidDocument = async (bidDocumentId) => {
         return null;
     }
 }
+
+exports.getBidDocumentsByProcurementBidId = async (procurementBidId) => {
+    try {
+        const bidDocuments = await db.BidDocument.findAll({
+            where: {
+                procurement_bid_id: procurementBidId,
+            },
+        });
+
+        return bidDocuments;
+    } catch (error) {
+        console.error("Error fetching bid documents: ", error);
+        return null;
+    }
+};

--- a/src/repositories/bidDocumentRepository.js
+++ b/src/repositories/bidDocumentRepository.js
@@ -1,0 +1,47 @@
+const db = require("../../database/models");
+
+exports.addBidDocument = async (procurementBidId, originalName, filePath, fileType) => {
+    try {
+        const bidDocument = await db.BidDocument.create({
+            procurement_bid_id: procurementBidId,
+            original_name: originalName,
+            file_path: filePath,
+            file_type: fileType,
+        });
+
+        return bidDocument;
+    } catch (error) {
+        console.error("Error adding a bid document: ", error);
+        return null;
+    }
+};
+
+exports.removeBidDocument = async (bidDocumentId) => {
+    try {
+        const bidDocument = await db.BidDocument.destroy({
+            where: {
+                id: bidDocumentId,
+            },
+        });
+
+        return bidDocument;
+    } catch (error) {
+        console.error("Error removing a bid document: ", error);
+        return false;
+    }
+};
+
+exports.getBidDocument = async (bidDocumentId) => {
+    try {
+        const bidDocument = await db.BidDocument.findOne({
+            where: {
+                id: bidDocumentId,
+            },
+        });
+
+        return bidDocument;
+    } catch (error) {
+        console.error("Error fetching a bid document: ", error);
+        return null;
+    }
+}

--- a/src/routes/bidDocumentRoutes.js
+++ b/src/routes/bidDocumentRoutes.js
@@ -1,13 +1,13 @@
 const express = require('express');
 const router = express.Router();
-const multer = require('multer');
 
 const bidDocumentController = require('../controllers/bidDocumentController');
 const { verifyToken } = require('../middleware/authMiddleware');
-const upload = multer();
+const upload = require('../middleware/uploadMiddleware');
 
 router.post('/bid-documents/upload', verifyToken, upload.single('file'), bidDocumentController.uploadBidDocument);
 router.delete('/bid-documents/:id/remove', verifyToken, bidDocumentController.deleteBidDocument);
+router.get('/procurement-bid/:id/bid-documents', verifyToken, bidDocumentController.getBidDocumentsByProcurementBidId);
 
 
 module.exports = router;

--- a/src/routes/bidDocumentRoutes.js
+++ b/src/routes/bidDocumentRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+
+const bidDocumentController = require('../controllers/bidDocumentController');
+const { verifyToken } = require('../middleware/authMiddleware');
+const upload = multer();
+
+router.post('/bid-documents/upload', verifyToken, upload.single('file'), bidDocumentController.uploadBidDocument);
+router.delete('/bid-documents/:id/remove', verifyToken, bidDocumentController.deleteBidDocument);
+
+
+module.exports = router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -5,7 +5,7 @@ const userController = require('../controllers/userController.js');
 const profileController = require("../controllers/profileController");
 
 const authMiddleware = require("../middleware/authMiddleware"); // provjera ulogovanog korisnika 
-const upload = require("../middleware/uploadMiddleware"); // middleware za upload slika
+const upload = require("../middleware/uploadImageMiddleware"); // middleware za upload slika
 const { registerValidator } = require('../middleware/userValidator.js');
 
 router.post('/user/register', registerValidator, userController.register);

--- a/src/services/bidDocumentService.js
+++ b/src/services/bidDocumentService.js
@@ -1,0 +1,18 @@
+const bidDocumentRepository = require("../repositories/bidDocumentRepository");
+const supabaseBucketService = require("../services/supabaseBucketService");
+
+exports.getBidDocumentsByProcurementBidId = async (procurementBidId) => {
+    const bidDocuments = await bidDocumentRepository.getBidDocumentsByProcurementBidId(procurementBidId);
+    if (!bidDocuments) {
+        return null;
+    }
+
+    const documentsWithUrls = bidDocuments.map(async (doc) => {
+        const fileUrl = await supabaseBucketService.getSignedUrl(doc.file_path);
+        const jsonDoc = doc.toJSON();
+        jsonDoc.file_url = fileUrl;
+        return jsonDoc;
+    });
+    
+    return Promise.all(documentsWithUrls);
+}

--- a/src/services/redisService.js
+++ b/src/services/redisService.js
@@ -1,0 +1,46 @@
+const { createClient } = require('redis');
+const redisConfig = require('../config/redis');
+const net = require('net');
+
+const redisUrl = new URL(redisConfig.redisUrl);
+const host = redisUrl.hostname;
+const port = parseInt(redisUrl.port, 10);
+
+let redisConnected = false;
+let redisClient = null;
+
+function checkRedisAvailable() {
+    return new Promise((resolve) => {
+        const socket = net.createConnection({ host, port });
+        socket.on('connect', () => {
+            socket.end();
+            resolve(true);
+        });
+        socket.on('error', () => {
+            resolve(false);
+        });
+    });
+}
+
+async function connectRedis() {
+    const isRedisAvailable = await checkRedisAvailable();
+    if (isRedisAvailable) {
+        redisClient = createClient({ url: redisUrl });
+        redisClient.on('error', (err) => console.error('Redis Client Error', err));
+
+        try {
+            await redisClient.connect();
+            redisConnected = true;
+        } catch (error) {
+            console.error('Error connecting to Redis:', error);
+        }
+    }
+    
+}
+
+connectRedis();
+
+module.exports = {
+    redisClient:() => redisClient,
+    redisConnected: () => redisConnected,
+};

--- a/src/services/supabaseBucketService.js
+++ b/src/services/supabaseBucketService.js
@@ -35,3 +35,15 @@ exports.deleteFile = async (filePath) => {
 
     return true;
 }
+
+exports.getSignedUrl = async (filePath, expiresIn = 86400) => { // 86400 = 24 hours
+    const { data, error } = await supabase.storage.from(bucketName)
+    .createSignedUrl(filePath, expiresIn);
+
+    if (error) {
+        console.error('Error generating signed URL:', error.message);
+        return null;
+    }
+
+    return data.signedUrl;
+};

--- a/src/services/supabaseBucketService.js
+++ b/src/services/supabaseBucketService.js
@@ -3,7 +3,7 @@ const supabaseConfig = require('../config/supabase');
 
 const supabaseUrl = supabaseConfig.url;
 const supabaseKey = supabaseConfig.secretKey;
-const bucketName = bucketName;
+const bucketName = supabaseConfig.bucketName;
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/src/services/supabaseBucketService.js
+++ b/src/services/supabaseBucketService.js
@@ -1,0 +1,37 @@
+const { createClient } = require('@supabase/supabase-js');
+const supabaseConfig = require('../config/supabase');
+
+const supabaseUrl = supabaseConfig.url;
+const supabaseKey = supabaseConfig.secretKey;
+const bucketName = bucketName;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+
+exports.uploadFile = async (fileBuffer, contentType, destinationPath) => {
+    const { data, error } = await supabase.storage.from(bucketName)
+    .upload(destinationPath, fileBuffer, {
+        contentType: contentType,
+        upsert: true, // TODO: change this later to upload to a new path (400 Asset Already Exists)
+    });
+
+    if (error) {
+        console.error('Upload error:', error);
+        return null;
+    }
+
+    return {
+        path: destinationPath
+    };
+}
+
+exports.deleteFile = async (filePath) => {
+    const { error } = await supabase.storage.from(bucketName).remove([filePath]);
+
+    if (error) {
+        console.error('Delete error:', error.message);
+        return null;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Created a private storage bucket on supabase called "**procurehub-storage**".

Added 3 new endpoints for working with bid documents:
- POST /bid-documents/upload - Upload bid document
- DELETE /bid-documents/:id/remove - Remove bid document
- GET /procurement-bid/:id/bid-documents - Get bid documents for a specific procurement request

New service: **supabaseBucketService** - for uploading/removing files and getting their public urls

New service: **redisService** - for caching previously generated signed urls

Modified existing **uploadMiddleware** to:
- allow only pdf, doc, docx, jpg, jpeg, png files not larger than 50 MB

Added new **uploadImageMiddleware** to:
- allow only jpg, jpeg, png files not larger than 50 MB

Modified profile update to use **uploadImagesMiddleware** and store to supabase bucket.
Modified return of profile info to include a public url from supabase

