### PR TITLE
Bid proposal/4 create edit feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const procurementRoutesBuyer = require('./src/routes/procurementRoutes.js');
 const categoryRoutes = require('./src/routes/categoryRoutes');
 const buyerTypeRoutes = require('./src/routes/buyerTypeRoutes.js');
 const procurementRoutes = require('./src/routes/procurementRequestRoutes.js');
+const bidProposalRoutes = require('./src/routes/bidProposalRoutes.js');
 
 const app = express();
 
@@ -31,6 +32,7 @@ app.use('/api', procurementRoutes);
 app.use('/api', categoryRoutes);
 app.use('/api', buyerTypeRoutes);
 app.use('/api', procurementRoutes);
+app.use('/api', bidProposalRoutes);
 
 app.listen(serverConfig.port, () => {
     console.log(`Server is running on port ${serverConfig.port}`);
@@ -52,7 +54,10 @@ app.listen(serverConfig.port, () => {
     - GET /api/procurement-requests/buyer - Get all procurement requests (buyers only)
     - GET /api/procurement-requests/favorites - Get favorite procurement requests (sellers only)
     - POST /api/procurement-requests/:id/follow - Follow (add to favorites) procurement request (sellers only)
-    - DELETE /api/procurement-requests/:id/unfollow - Unfollow (remove from favorites) procurement request (sellers only)`);
+    - DELETE /api/procurement-requests/:id/unfollow - Unfollow (remove from favorites) procurement request (sellers only)
+    - POST /api/bid/create - Create a new bid (sellers only)
+    - PUT /api/bid/:id/update - Update a bid (sellers only)
+    - PUT /api/bid/:id/submit - Submit a bid (sellers only)`);
 });
 
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ app.use('/api', procurementRoutes);
 app.use('/api', categoryRoutes);
 app.use('/api', buyerTypeRoutes);
 app.use('/api', procurementRoutes);
-app.use('/api', bidProposalRoutes);
+app.use('/api', bidProposalRoutes)
 
 app.listen(serverConfig.port, () => {
     console.log(`Server is running on port ${serverConfig.port}`);
@@ -56,8 +56,9 @@ app.listen(serverConfig.port, () => {
     - POST /api/procurement-requests/:id/follow - Follow (add to favorites) procurement request (sellers only)
     - DELETE /api/procurement-requests/:id/unfollow - Unfollow (remove from favorites) procurement request (sellers only)
     - POST /api/bid/create - Create a new bid (sellers only)
-    - PUT /api/bid/:id/update - Update a bid (sellers only)
-    - PUT /api/bid/:id/submit - Submit a bid (sellers only)`);
+    - PUT /api/bid/:id/update - Update a bid that's not submitted (sellers only)
+    - PUT /api/bid/:id/submit - Submit a bid (sellers only)
+    - GET /api/bid/:id/preview - Preview a bid (sellers only)`);
 });
 
 

--- a/src/controllers/bidProposalControllers.js
+++ b/src/controllers/bidProposalControllers.js
@@ -87,9 +87,16 @@ exports.updateDraftBid = async (req, res) => {
       }
   
       const request = await ProcurementRequest.findByPk(bid.procurement_request_id);
-        if (!request) {
-            return res.status(400).json({ message: 'Procurement request not found' });
-        }
+      if (!request) {
+        return res.status(400).json({ message: 'Procurement request not found' });
+      }
+
+      if(request.deadline < new Date()){
+        return res.status(400).json({ message: 'Procurement request deadline has passed!' });
+      }
+      if (request.status !== 'active') {
+        return res.status(400).json({ message: 'Procurement request is not active.' });
+      }
       // Build an object with only the fields that are present
       const updatedFields = {};
       if (price !== undefined){
@@ -141,6 +148,13 @@ exports.submitDraftBid = async (req, res) => {
         }
         if(req.user.status !== 'active') {
           return res.status(403).json({ message: 'Your account is not active. Please contact support.' });
+        }
+
+        if(request.deadline < new Date()){
+          return res.status(400).json({ message: 'Procurement request deadline has passed!' });
+        }
+        if (request.status !== 'active') {
+          return res.status(400).json({ message: 'Procurement request is not active.' });
         }
 
         // Check if the bid is already submitted

--- a/src/controllers/bidProposalControllers.js
+++ b/src/controllers/bidProposalControllers.js
@@ -1,0 +1,189 @@
+const {ProcurementBid, User, ProcurementRequest} = require('../../database/models');
+
+
+exports.createBid = async (req, res) => {
+    try {
+        const { procurement_request_id, price, timeline, proposal_text, submitted } = req.body;
+
+        const user = await User.findByPk(req.user.id);
+        if (!user || user.role !== 'seller') {
+          return res.status(403).json({ message: 'You do not have the required role to create a procurement request' });
+        }
+        if(user.status !== 'active') {
+          return res.status(403).json({ message: 'Your account is not active. Please contact support.' });
+        }
+
+
+        
+        // Validate the request body
+        if (!procurement_request_id || !price || !timeline || !proposal_text) {
+            return res.status(400).json({ message: 'All fields are required.'});
+        }
+
+        // Check if the procurement requesr exists, its deadline hasn't passed, and its status is active
+        const request = await ProcurementRequest.findByPk(procurement_request_id);
+        if (!request) {
+            return res.status(400).json({ message: 'Procurement request not found' });
+        }
+        if (new Date() > new Date(request.deadline)){
+            return res.status(400).json({ message: 'Procurement request deadline has passed!' });
+        }
+        if (request.status !== 'active') {
+            return res.status(400).json({ message: 'Procurement request is not active.' });
+        }
+
+
+        // Check if bid price is within the procurement request budget range
+        if (price < request.budget_min || price > request.budget_max) {
+            return res.status(400).json({ message: 'Price must be within the budget range.'});
+        }
+        if (price < 0) {
+            return res.status(400).json({ message: 'Price cannot be negative.'});
+        }
+
+        currentDate = new Date();
+        
+        // Create the bid
+        const bid = await ProcurementBid.create({
+            seller_id: user.id,
+            procurement_request_id,
+            price,
+            timeline,
+            proposal_text,
+            submitted_at: currentDate,
+            submitted_at: submitted ? new Date() : null,
+        });
+
+        return res.status(200).json({ message: 'Bid created successfully', bid });
+
+    } catch (error) {
+        console.error('Error while creating bid:', error);
+        return res.status(500).json({ message: 'Internal server error.' });
+    }
+}
+
+
+exports.updateDraftBid = async (req, res) => {
+    try {
+      const { id } = req.params;
+      const { price, timeline, proposal_text } = req.body;
+  
+      // Check if the bid exists
+      const bid = await ProcurementBid.findByPk(id);
+      if (!bid) {
+        return res.status(404).json({ message: 'Bid not found' });
+      }
+  
+      if (bid.submitted_at) {
+        return res.status(400).json({ message: 'Bid has already been submitted and cannot be updated' });
+      }
+  
+      // Check if the user is the seller of the bid
+      if (!req.user || bid.seller_id !== req.user.id) {
+        return res.status(403).json({ message: 'You do not have permission to update this bid' });
+      }
+      if(req.user.status !== 'active') {
+        return res.status(403).json({ message: 'Your account is not active. Please contact support.' });
+      }
+  
+      const request = await ProcurementRequest.findByPk(bid.procurement_request_id);
+        if (!request) {
+            return res.status(400).json({ message: 'Procurement request not found' });
+        }
+      // Build an object with only the fields that are present
+      const updatedFields = {};
+      if (price !== undefined){
+        // Check if the price is within the procurement request budget range
+        if (!request) {
+            return res.status(400).json({ message: 'Procurement request not found' });
+        }
+        if (price < request.budget_min || price > request.budget_max) {
+            return res.status(400).json({ message: 'Price must be within the budget range.'});
+        }
+        if (price < 0) {
+            return res.status(400).json({ message: 'Price cannot be negative.'});
+        }
+        updatedFields.price = price;
+      } 
+      if (timeline !== undefined) updatedFields.timeline = timeline;
+      if (proposal_text !== undefined) updatedFields.proposal_text = proposal_text;
+  
+      // If no fields were provided
+      if (Object.keys(updatedFields).length === 0) {
+        return res.status(400).json({ message: 'No valid fields provided to update.' });
+      }
+  
+      // Update the bid with the provided fields
+      await bid.update(updatedFields);
+  
+      return res.status(200).json({ message: 'Bid updated successfully', bid });
+  
+    } catch (error) {
+      console.error('Error updating draft bid:', error);
+      return res.status(500).json({ message: 'An error occurred while updating the draft bid.' });
+    }
+  };
+  
+
+exports.submitDraftBid = async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        // Check if the bid exists
+        const bid = await ProcurementBid.findByPk(id);
+        if (!bid) {
+            return res.status(404).json({ message: 'Bid not found' });
+        }
+
+        // Check if the user is the seller of the bid
+        if (!req.user || req.user.id !== bid.seller_id) {
+            return res.status(403).json({ message: 'You do not have the required role to submit this bid' });
+        }
+        if(req.user.status !== 'active') {
+          return res.status(403).json({ message: 'Your account is not active. Please contact support.' });
+        }
+
+        // Check if the bid is already submitted
+        if (bid.submitted_at) {
+            return res.status(400).json({ message: 'Bid has already been submitted' });
+        }
+
+        // Update the bid to mark it as submitted
+        await bid.update({
+            submitted_at: new Date(),
+        });
+
+        return res.status(200).json({ message: 'Bid submitted successfully', bid });
+
+    } catch (error) {
+        console.error('Error submitting bid:', error);
+        return res.status(500).json({ message: 'An error occurred while submitting the bid.' });
+    }
+}
+
+exports.previewBid = async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        // Check if the bid exists
+        const bid = await ProcurementBid.findByPk(id);
+        if (!bid) {
+            return res.status(404).json({ message: 'Bid not found' });
+        }
+
+        // Check if the user is the seller of the bid
+        if (!req.user || req.user.id !== bid.seller_id) {
+            return res.status(403).json({ message: 'You do not have the required role to preview this bid' });
+        }
+        if(req.user.status !== 'active') {
+          return res.status(403).json({ message: 'Your account is not active. Please contact support.' });
+        }
+
+        return res.status(200).json({ message: 'Bid preview', bid });
+
+    } catch (error) {
+        console.error('Error previewing bid:', error);
+        return res.status(500).json({ message: 'An error occurred while previewing the bid.' });
+    }
+}
+

--- a/src/routes/bidProposalRoutes.js
+++ b/src/routes/bidProposalRoutes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const bidProposalController = require('../controllers/bidProposalControllers');
+const { verifyToken } = require('../middleware/authMiddleware');
+const { verify } = require('jsonwebtoken');
+
+
+// Route for creating a bid
+router.post('/bid/create', verifyToken, bidProposalController.createBid);
+
+// Route for updating a bid
+router.put('/bid/:id/update', verifyToken, bidProposalController.updateDraftBid);
+
+// Route for submitting a bid
+router.put('/bid/:id/submit', verifyToken, bidProposalController.submitDraftBid);
+
+// Route for previewing bit by ID
+router.get('/bid/:id/preview', verifyToken, bidProposalController.previewBid);
+
+module.exports = router;


### PR DESCRIPTION
### POST /api/bid/create:

<img width="850" alt="Screenshot 2025-04-21 at 10 09 09" src="https://github.com/user-attachments/assets/e6c9ac8b-00f0-453c-8735-f1059dff47cf" />

When creating a bid, all four of these fields are required. This creates a draft bid.
There are validations checking whether the logged in user is a seller, whether the procurement request exists and whether the price is inside of the request's budget.

User validation:

<img width="850" alt="Screenshot 2025-04-21 at 10 13 11" src="https://github.com/user-attachments/assets/4e5aa04d-9173-4ad6-9ab8-a26bc5d27400" />

Request field validation:

<img width="850" alt="Screenshot 2025-04-21 at 10 15 11" src="https://github.com/user-attachments/assets/e63f9ad5-3257-424e-8803-e61a62fad32f" />

<img width="850" alt="Screenshot 2025-04-21 at 10 15 25" src="https://github.com/user-attachments/assets/b7590241-d8b4-4742-bf93-0e4407ffdc64" />

Price validation: 

<img width="850" alt="Screenshot 2025-04-21 at 10 15 42" src="https://github.com/user-attachments/assets/acd7ef53-c0a3-4545-9544-873446ed777a" />

A bid cannot be created if the procurement request's deadline has passed:

<img width="908" alt="Screenshot 2025-04-21 at 10 21 29" src="https://github.com/user-attachments/assets/4b584248-cc05-4551-8457-0377e0047922" />

There is a fifth, optional, field 'submitted' which, if true, automatically submits the bid.

<img width="850" alt="Screenshot 2025-04-21 at 10 10 37" src="https://github.com/user-attachments/assets/59be10c7-4d9c-4e4e-b013-38b006692cf3" />


### PUT /api/bid/:id/update:

The json body of this request is mainly the same, except the optional 'submitted' field being omitted and the other fields not being required.

The same validations are done on the fields as when creating the bid.

<img width="908" alt="Screenshot 2025-04-21 at 10 19 47" src="https://github.com/user-attachments/assets/a52ca631-df53-4688-af09-4d0755b2c52f" />

Already submitted bids cannot be updated.

<img width="908" alt="Screenshot 2025-04-21 at 10 20 29" src="https://github.com/user-attachments/assets/629dedd7-f7a6-4596-a39a-a6e3bd8c5b42" />

Bids connected to procurement requests that are not active or whose deadline passed cannot be updated.
Only the user that created the bid (that also must be a seller) can update the bid.


### PUT /api/bid/:id/submit:

This request has no json body, it just submits the bid that is forwarded as a parameter.

<img width="908" alt="Screenshot 2025-04-21 at 10 23 20" src="https://github.com/user-attachments/assets/5e5fa1a0-e325-423e-9f30-266f7e332248" />

Bids connected to inactive procurement requests, or whose deadlines already passed, cannot be submitted.

Only the user that created the bid (that also must be a seller) can submit the bid.


### PUT /api/bid/:id/preview:

This request just returns information about the bid sent as a parameter. Only the creator of the bid can preview it.

<img width="908" alt="Screenshot 2025-04-21 at 10 25 55" src="https://github.com/user-attachments/assets/77017a16-7827-4285-92c7-2c9ee81cd543" />







