### PR TITLE
Database migrations sprint 9

### DIFF
--- a/database/migrations/20250529115407-add_coloumn_seller_bank_account_to_users_table.js
+++ b/database/migrations/20250529115407-add_coloumn_seller_bank_account_to_users_table.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('users', 'seller_bank_account', {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('users', 'seller_bank_account');
+  }
+};
+

--- a/database/migrations/20250529121012-add_details_coloumns_to_contracts_table.js
+++ b/database/migrations/20250529121012-add_details_coloumns_to_contracts_table.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await Promise.all([
+      queryInterface.addColumn('contracts', 'status', {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+        defaultValue: 'pending',
+      }),
+      queryInterface.addColumn('contracts', 'price', {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      }),
+      queryInterface.addColumn('contracts', 'timeline', {
+        type: Sequelize.STRING,
+        allowNull: false,
+      }),
+      queryInterface.addColumn('contracts', 'original_name', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }),
+      queryInterface.addColumn('contracts', 'contract_path', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }),
+      queryInterface.addColumn('contracts', 'file_type', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }),
+      
+    ]);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await Promise.all([
+      queryInterface.removeColumn('contracts', 'status'),
+      queryInterface.removeColumn('contracts', 'price'),
+      queryInterface.removeColumn('contracts', 'timeline'),
+      queryInterface.removeColumn('contracts', 'original_name'),
+      queryInterface.removeColumn('contracts', 'contract_path'),
+      queryInterface.removeColumn('contracts', 'file_type'),
+    ]);
+  }
+};
+

--- a/database/migrations/20250529123434-create_payment_instructions_table.js
+++ b/database/migrations/20250529123434-create_payment_instructions_table.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('payment_instructions', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'contracts',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      payment_policy: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      date: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      amount: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('payment_instructions');
+  }
+};
+

--- a/database/migrations/20250529125325-create_contract_logs_table.js
+++ b/database/migrations/20250529125325-create_contract_logs_table.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('contract_logs', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'contracts',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      action: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      timestamp: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('contract_logs');
+  }
+};
+

--- a/database/migrations/20250529131340-create_notifications_table.js
+++ b/database/migrations/20250529131340-create_notifications_table.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('notifications', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'contracts',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      text: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('notifications'); 
+  }
+};
+
+

--- a/database/migrations/20250529132927-create_contract_change_requests_table.js
+++ b/database/migrations/20250529132927-create_contract_change_requests_table.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('contract_change_requests', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'contracts',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      seller_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      message: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('contract_change_requests');
+  },
+};
+

--- a/database/migrations/20250529145555-add_timestamps_to_contract_logs_table.js
+++ b/database/migrations/20250529145555-add_timestamps_to_contract_logs_table.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('contract_logs', 'created_at', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    });
+
+    await queryInterface.addColumn('contract_logs', 'updated_at', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('contract_logs', 'created_at');
+    await queryInterface.removeColumn('contract_logs', 'updated_at');
+  }
+};
+

--- a/database/migrations/20250529150625-add_timestamps_to_payment_instructions_table.js
+++ b/database/migrations/20250529150625-add_timestamps_to_payment_instructions_table.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('payment_instructions', 'created_at', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    });
+
+    await queryInterface.addColumn('payment_instructions', 'updated_at', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('payment_instructions', 'created_at');
+    await queryInterface.removeColumn('payment_instructions', 'updated_at');
+  }
+};

--- a/database/migrations/20250529151104-add_timestamps_to_contract_change_requests_table.js
+++ b/database/migrations/20250529151104-add_timestamps_to_contract_change_requests_table.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('contract_change_requests', 'updated_at', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('contract_change_requests', 'updated_at');
+  }
+};

--- a/database/migrations/20250529153032-remove_timestamp_coloumn_from_contract_logs_table.js
+++ b/database/migrations/20250529153032-remove_timestamp_coloumn_from_contract_logs_table.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('contract_logs', 'timestamp');
+    await queryInterface.removeColumn('contract_logs', 'updated_at');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn('contract_logs', 'timestamp', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    });
+
+    await queryInterface.addColumn('contract_logs', 'updated_at', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    });
+  }
+};
+

--- a/database/models/contract.js
+++ b/database/models/contract.js
@@ -18,6 +18,30 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'contract_id',
         as: 'disputes',
       });
+      
+      Contract.hasMany(models.PaymentInstruction, {
+        foreignKey: 'contract_id',
+        as: 'paymentInstructions',
+      });
+
+      Contract.hasMany(models.ContractLog, {
+        foreignKey: 'contract_id',
+        as: 'logs',
+      });
+
+      Contract.hasMany(models.Notification, {
+        foreignKey: 'contract_id',
+        as: 'notifications',
+      });
+
+      Contract.hasMany(models.ContractChangeRequest, {
+        foreignKey: 'contract_id',
+        as: 'changeRequests',
+      });
+
+
+
+
     }
   }
 
@@ -37,6 +61,31 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: false,
       },
+      status: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+      defaultValue: 'pending',
+      },
+      price: {
+        type: DataTypes.FLOAT,
+        allowNull: false,
+      },
+      timeline: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      original_name: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      contract_path: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      file_type: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      }
     },
     {
       sequelize,

--- a/database/models/contractchangerequest.js
+++ b/database/models/contractchangerequest.js
@@ -1,0 +1,59 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class ContractChangeRequest extends Model {
+    static associate(models) {
+      ContractChangeRequest.belongsTo(models.Contract, {
+        foreignKey: 'contract_id',
+        as: 'contract',
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      });
+
+      ContractChangeRequest.belongsTo(models.User, {
+        foreignKey: 'seller_id',
+        as: 'seller',
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      });
+    }
+  }
+
+  ContractChangeRequest.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      seller_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      message: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    },
+    {
+      sequelize,
+      modelName: 'ContractChangeRequest',
+      tableName: 'contract_change_requests',
+      underscored: true,
+      timestamps: false, 
+    }
+  );
+
+  return ContractChangeRequest;
+};

--- a/database/models/contractchangerequest.js
+++ b/database/models/contractchangerequest.js
@@ -51,7 +51,9 @@ module.exports = (sequelize, DataTypes) => {
       modelName: 'ContractChangeRequest',
       tableName: 'contract_change_requests',
       underscored: true,
-      timestamps: false, 
+      timestamps: true, 
+      createdAt: 'created_at',
+      updatedAt: 'updated_at'
     }
   );
 

--- a/database/models/contractlog.js
+++ b/database/models/contractlog.js
@@ -40,7 +40,7 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: false,
       },
-      timestamp: {
+      created_at: {
         type: DataTypes.DATE,
         allowNull: false,
         defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
@@ -52,6 +52,7 @@ module.exports = (sequelize, DataTypes) => {
       tableName: 'contract_logs',
       underscored: true,
       timestamps: false,
+      
     }
   );
 

--- a/database/models/contractlog.js
+++ b/database/models/contractlog.js
@@ -1,0 +1,59 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class ContractLog extends Model {
+    static associate(models) {
+      ContractLog.belongsTo(models.Contract, {
+        foreignKey: 'contract_id',
+        as: 'contract',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+
+      ContractLog.belongsTo(models.User, {
+        foreignKey: 'user_id',
+        as: 'user',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+    }
+  }
+
+  ContractLog.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      action: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      user_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      timestamp: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    },
+    {
+      sequelize,
+      modelName: 'ContractLog',
+      tableName: 'contract_logs',
+      underscored: true,
+      timestamps: false,
+    }
+  );
+
+  return ContractLog;
+};

--- a/database/models/notification.js
+++ b/database/models/notification.js
@@ -1,0 +1,57 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class Notification extends Model {
+    static associate(models) {
+
+      Notification.belongsTo(models.Contract, {
+        foreignKey: 'contract_id',
+        as: 'contract',
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      });
+
+      Notification.belongsTo(models.User, {
+        foreignKey: 'user_id',
+        as: 'user',
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      });
+    }
+  }
+
+  Notification.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      user_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      text: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+    },
+    {
+      sequelize,
+      modelName: 'Notification',
+      tableName: 'notifications',
+      underscored: true,
+      timestamps: true,
+      createdAt: 'created_at',
+      updatedAt: 'updated_at',
+    }
+  );
+
+  return Notification;
+};

--- a/database/models/paymentinstruction.js
+++ b/database/models/paymentinstruction.js
@@ -1,0 +1,51 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class PaymentInstruction extends Model {
+    static associate(models) {
+      PaymentInstruction.belongsTo(models.Contract, {
+        foreignKey: 'contract_id',
+        as: 'contract',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+    }
+  }
+
+  PaymentInstruction.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      contract_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      payment_policy: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      date: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      amount: {
+        type: DataTypes.FLOAT,
+        allowNull: false,
+      },
+    },
+    {
+      sequelize,
+      modelName: 'PaymentInstruction',
+      tableName: 'payment_instructions',
+      underscored: true,
+      timestamps: false,
+    }
+  );
+
+  return PaymentInstruction;
+};

--- a/database/models/paymentinstruction.js
+++ b/database/models/paymentinstruction.js
@@ -43,7 +43,9 @@ module.exports = (sequelize, DataTypes) => {
       modelName: 'PaymentInstruction',
       tableName: 'payment_instructions',
       underscored: true,
-      timestamps: false,
+      timestamps: true,
+      createdAt: 'created_at',
+      updatedAt: 'updated_at'
     }
   );
 

--- a/database/models/user.js
+++ b/database/models/user.js
@@ -50,6 +50,27 @@ module.exports = (sequelize, DataTypes) => {
         onUpdate: 'CASCADE',
         onDelete: 'CASCADE',
       });
+
+      User.hasMany(models.ContractLog, {
+        foreignKey: 'user_id',
+        as: 'contractLogs',
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      });
+
+      User.hasMany(models.Notification, {
+        foreignKey: 'user_id',
+        as: 'notifications',
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      });
+
+      User.hasMany(models.ContractChangeRequest, {
+        foreignKey: 'seller_id',
+        as: 'changeRequests',
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      });
     }
   }
 
@@ -156,6 +177,10 @@ module.exports = (sequelize, DataTypes) => {
       },
       onUpdate: 'CASCADE',
       onDelete: 'SET NULL'
+    },
+    seller_bank_account: {
+      type: DataTypes.STRING(255),
+      allowNull: true
     }
   }, {
     sequelize,


### PR DESCRIPTION
Migrations sprint 9 #118 
Updated tables: users and contracts.
Created tables: payment_instructions, contract_logs, notifications and contract_change_request.
Tables payment_instructions, contract_logs and contract_change_request are without sequelize timestamps.